### PR TITLE
Fix SVD dimension mismatch and optimize matrix computations. Added detailed documentation and backward compatibility for redundant delta to alpha conversion.

### DIFF
--- a/copterr/__init__.py
+++ b/copterr/__init__.py
@@ -1,1 +1,9 @@
-from .copterr import *
+from .copterr import PermuteWeights, PermuteWeightsGrouped
+from .utils import alphas_to_deltas, quantize_alphas
+
+__all__ = [
+    'PermuteWeights',
+    'PermuteWeightsGrouped', 
+    'alphas_to_deltas',
+    'quantize_alphas'
+]

--- a/copterr/copterr.py
+++ b/copterr/copterr.py
@@ -9,19 +9,47 @@ from .utils import (
 )
 
 class PermuteWeights():
-    def __init__(self, X, Y, alphas, device='cpu', dtype=torch.float):
+    """
+    A class to perform permutation-based weight fitting using Singular Value Decomposition (SVD).
+
+    Attributes:
+        X (array-like): The input feature matrix. shape: n_samples x n_features
+        Y (array-like): The target matrix. shape: n_samples x n_voxels
+        alphas (array-like): Regularization parameters for each feature. shape: 1 x n_voxels
+        device (str): The device to perform computations on ('cpu' or 'cuda').
+        dtype (torch.dtype): The data type for torch tensors.
+        full_matrices (bool): Whether to compute the full SVD or reduced SVD.
+    """
+
+    def __init__(self, X, Y, alphas, device='cpu', dtype=torch.float, full_matrices=False):
+        """
+        Args:
+            X (array-like): The input feature matrix.
+            Y (array-like): The target matrix.
+            alphas (array-like): Regularization parameters for each feature.
+            device (str): The device to perform computations on ('cpu' or 'cuda').
+            dtype (torch.dtype): The data type for torch tensors.
+            full_matrices (bool): Whether to compute the full SVD or reduced SVD.
+        """
         self.device = device
         self.dtype = dtype
         self.X = X
         self.Y = torch.tensor(Y, device=self.device, dtype=self.dtype)
         self.alphas = alphas
         self.weights = torch.zeros((self.X.shape[1], self.Y.shape[1]), device=self.device, dtype=self.dtype)
+        self.full_matrices = full_matrices
 
     def prepare(self, verbose=True):
+        """
+        Prepares the SVD components for each unique alpha value.
+
+        Args:
+            verbose (bool): If True, displays a progress bar during computation.
+        """
         unique_alphas, alphas_idxs = np.unique(self.alphas, axis=0, return_inverse=True)
         self._alpha_masks = [alphas_idxs==i for i in range(len(unique_alphas))]
         self._all_VDUt = []
-        U, s, Vt = scipy.linalg.svd(self.X, full_matrices=False)
+        U, s, Vt = scipy.linalg.svd(self.X, full_matrices=self.full_matrices)
         if verbose:
             unique_alphas = tqdm(unique_alphas, desc='Computing Initial SVDs')
         for alpha in unique_alphas:
@@ -30,15 +58,44 @@ class PermuteWeights():
             self._all_VDUt.append(torch.tensor(VDUt, device=self.device, dtype=self.dtype))
         
     def fit_true_weights(self):
+        """
+        Fits the true weights without permutation.
+
+        Returns:
+            torch.Tensor: The fitted weights.
+        """
         return self.fit_permutation(permutation=False)
     
     def fit_permutation(self, permutation=True, block_len=1):
+        """
+        Fits the weights using permutation testing.
+
+        Args:
+            permutation (bool): If True, permutes the target data.
+            block_len (int): The block length for permutation.
+
+        Returns:
+            torch.Tensor: The fitted weights.
+        """
         perm_idxs = _process_perm_idxs(permutation, len(self.Y), block_len)
         for alpha_mask, VDUt in zip(self._alpha_masks, self._all_VDUt):
             self.weights[:,alpha_mask] = VDUt @ self.Y[perm_idxs][:,alpha_mask]
         return self.weights
     
     def score(self, Xtest, Ytest, permutation=False, block_len=1, correlation=False):
+        """
+        Scores the model using test data.
+
+        Args:
+            Xtest (array-like): The test feature matrix.
+            Ytest (array-like): The test target matrix.
+            permutation (bool): If True, permutes the test target data.
+            block_len (int): The block length for permutation.
+            correlation (bool): If True, returns correlation scores.
+
+        Returns:
+            torch.Tensor: The score of the model.
+        """
         Xtest = torch.tensor(Xtest, device=self.device, dtype=self.dtype)
         Ytest = torch.tensor(Ytest, device=self.device, dtype=self.dtype)
         perm_idxs = _process_perm_idxs(permutation, Ytest.shape[-2], block_len)
@@ -51,17 +108,58 @@ class PermuteWeights():
 
 
 class PermuteWeightsGrouped():
-    def __init__(self, X, Y, deltas, device='cpu', dtype=torch.float):
+    """
+    A class to perform permutation-based weight fitting for grouped feature spaces using SVD.
+
+    Attributes:
+        X (array-like): The concatenated n features of input feature matrix from multiple groups. shape: its a list with each element being n_samples x n_features
+        Y (array-like): The target matrix. shape: n_samples x n_voxels
+        alphas (array-like): Regularization parameters for each feature group. shape: n_features x n_voxels
+        deltas (numpy.ndarray, optional): Regularization parameters in delta form (deprecated).
+                If provided and 'alphas' is None, they will be automatically converted to alphas.
+        device (str): The device to perform computations on ('cpu' or 'cuda').
+        dtype (torch.dtype): The data type for torch tensors.
+        full_matrices (bool): Whether to compute the full SVD or reduced SVD.
+    """
+
+    def __init__(self, X, Y, alphas=None, deltas=None, device='cpu', dtype=torch.float, full_matrices=True):
+        """
+        Args:
+            X (array-like): The concatenated input feature matrix from multiple groups.
+            Y (array-like): The target matrix.
+            alphas (array-like): Regularization parameters for each feature group.
+            deltas (numpy.ndarray, optional): Regularization parameters in delta form (deprecated).
+                If provided and 'alphas' is None, they will be automatically converted to alphas.
+            device (str): The device to perform computations on ('cpu' or 'cuda').
+            dtype (torch.dtype): The data type for torch tensors.
+            full_matrices (bool): Whether to compute the full SVD or reduced SVD.
+        Raises:
+            ValueError: If neither 'alphas' nor 'deltas' is provided.
+        """
         self.device = device
         self.dtype = dtype
         self.feature_counts = [fs.shape[1] for fs in X]
         self.X = np.concatenate(X, axis=1)
         self.Y = torch.tensor(Y, device=self.device, dtype=self.dtype)
-        if deltas is not None:
-            self.alphas = deltas_to_alphas(deltas)
+        # Backward compatibility: if alphas is not provided but deltas is provided,
+        # compute alphas from deltas. Moving forward, new code should provide alphas.
+        if alphas is None:
+            if deltas is not None:
+                self.alphas = deltas_to_alphas(deltas)
+            else:
+                raise ValueError("One of 'alphas' or 'deltas' must be provided.")
+        else:
+            self.alphas = alphas
         self.weights = torch.zeros((self.X.shape[1], self.Y.shape[1]), device=self.device, dtype=self.dtype)
+        self.full_matrices = full_matrices
 
     def prepare(self, verbose=True):
+        """
+        Prepares the SVD components for each unique alpha value, considering grouped feature spaces.
+
+        Args:
+            verbose (bool): If True, displays a progress bar during computation.
+        """
         unique_alphas, alphas_idxs = np.unique(self.alphas, axis=0, return_inverse=True)
         self._alpha_masks = [alphas_idxs==i for i in range(len(unique_alphas))]
         self._all_VDUt = []
@@ -69,21 +167,57 @@ class PermuteWeightsGrouped():
             unique_alphas = tqdm(unique_alphas, desc='Computing Initial SVDs')
         for alpha in unique_alphas:
             scaling = np.hstack([np.full(fs_size, a**.5) for fs_size, a in zip(self.feature_counts, alpha)])
-            U, s, Vt = scipy.linalg.svd(self.X/scaling, full_matrices=True)
+            U, s, Vt = scipy.linalg.svd(self.X/scaling, full_matrices=self.full_matrices)
             d = s/(s**2 + 1)
-            VDUt = ((1/scaling * Vt).T[:,:len(d)] * d) @ U.T
+            if self.full_matrices: # this should be back compatible with previous version, but having full_matrices=True may lead to extra computation in SVD with part of the matrix unused because of the indexing any way.
+                if self.X.shape[0] < self.X.shape[1]:  # wide matrix
+                    VDUt = ((1/scaling * Vt).T[:,:len(d)] * d) @ U.T
+                else:  # tall matrix
+                    VDUt = ((1/scaling * Vt).T * d) @ U.T[:len(d),:]
+            else:
+                VDUt = ((1/scaling * Vt).T * d) @ U.T
+
             self._all_VDUt.append(torch.tensor(VDUt, device=self.device, dtype=self.dtype))
     
     def fit_true_weights(self):
+        """
+        Fits the true weights without permutation.
+
+        Returns:
+            torch.Tensor: The fitted weights.
+        """
         return self.fit_permutation(permutation=False)
     
     def fit_permutation(self, permutation=True, block_len=1):
+        """
+        Fits the weights using permutation testing for grouped feature spaces.
+
+        Args:
+            permutation (bool): If True, permutes the target data.
+            block_len (int): The block length for permutation.
+
+        Returns:
+            torch.Tensor: The fitted weights.
+        """
         perm_idxs = _process_perm_idxs(permutation, len(self.Y), block_len)
         for alpha_mask, VDUt in zip(self._alpha_masks, self._all_VDUt):
             self.weights[:,alpha_mask] = VDUt @ self.Y[perm_idxs][:,alpha_mask]
         return self.weights
     
     def score(self, Xtest, Ytest, permutation=False, block_len=1, correlation=False):
+        """
+        Scores the model using test data for grouped feature spaces.
+
+        Args:
+            Xtest (array-like): The test feature matrix.
+            Ytest (array-like): The test target matrix.
+            permutation (bool): If True, permutes the test target data.
+            block_len (int): The block length for permutation.
+            correlation (bool): If True, returns correlation scores.
+
+        Returns:
+            torch.Tensor: The score of the model.
+        """
         Xtest = torch.tensor(Xtest, device=self.device, dtype=self.dtype)
         Ytest = torch.tensor(Ytest, device=self.device, dtype=self.dtype)
         perm_idxs = _process_perm_idxs(permutation, Ytest.shape[-2], block_len)

--- a/copterr/copterr.py
+++ b/copterr/copterr.py
@@ -160,11 +160,18 @@ class PermuteWeightsGrouped():
         Args:
             verbose (bool): If True, displays a progress bar during computation.
         """
-        unique_alphas, alphas_idxs = np.unique(self.alphas, axis=0, return_inverse=True)
+        # Convert alphas to a hashable type for unique operation
+        alphas_tuple = tuple(map(tuple, self.alphas.T))
+        unique_alphas_tuple = list(set(alphas_tuple))
+        alphas_idxs = np.array([unique_alphas_tuple.index(a) for a in alphas_tuple])
+        unique_alphas = np.array(unique_alphas_tuple)
+        
         self._alpha_masks = [alphas_idxs==i for i in range(len(unique_alphas))]
         self._all_VDUt = []
+        
         if verbose:
             unique_alphas = tqdm(unique_alphas, desc='Computing Initial SVDs')
+            
         for alpha in unique_alphas:
             scaling = np.hstack([np.full(fs_size, a**.5) for fs_size, a in zip(self.feature_counts, alpha)])
             U, s, Vt = scipy.linalg.svd(self.X/scaling, full_matrices=self.full_matrices)

--- a/copterr/utils.py
+++ b/copterr/utils.py
@@ -13,7 +13,7 @@ def create_permutation_idxs(n_timepoints, n_permutations, block_len=1):
     return permutation_idxs
 
 
-def column_corr_torch(A, B, unbiased=False):
+def column_corr_torch(A, B, unbiased=False, epsilon=1e-10):
     """Similar to Stats.utils.column_corr, except works with tensors.  Should be tested more
     thoroughly for possible differences.
 
@@ -26,6 +26,9 @@ def column_corr_torch(A, B, unbiased=False):
     unbiased : bool
         Whether to compute std as a biased estimator.  False computes equivalently to 
         dof=0 in column_corr.
+    epsilon : float, default=1e-10
+        Small constant added to the standard deviation to prevent division by zero
+        or numerical instability with near-zero variance features.
 
     Returns
     -------
@@ -34,7 +37,7 @@ def column_corr_torch(A, B, unbiased=False):
         columns of arrays A and B.
     """
     def zs(x): 
-        return (x-torch.mean(x, dim=-2, keepdims=True)) / torch.std(x, dim=-2, keepdims=True, unbiased=unbiased)
+        return (x-torch.mean(x, dim=-2, keepdims=True)) / (torch.std(x, dim=-2, keepdims=True, unbiased=unbiased) + epsilon)
     rTmp = torch.sum(zs(A)*zs(B), dim=-2, keepdims=True)
     n = A.shape[0]
     # make sure not to count nans

--- a/copterr_commit_demo.py
+++ b/copterr_commit_demo.py
@@ -1,0 +1,81 @@
+'''
+Summary
+Fix SVD dimension mismatch and optimize matrix computations. Added detailed documentation and backward compatibility for redundant delta to alpha conversion.
+
+Main Changes:
+1. Added dimension-aware matrix handling for SVD operations:
+   - For wide matrices (samples < features): slice Vt.T
+   - For tall matrices (samples > features): slice U.T
+2. Maintained backward compatibility with full_matrices=True
+3. Added optimized path using full_matrices=False that avoids computing unused matrix components
+4. Added detailed documentation for copterr.py file.
+5. Ensured backward compatibility for the `deltas` parameter.
+6. Added explicit imports in the `__init__.py` file.
+
+Technical Details:
+- Previous code assumed wide matrices (common in fMRI).
+- New code handles both wide and tall matrices correctly.
+- Setting full_matrices=False is computationally optimal but optional.
+
+Demonstration:
+See `copterr_commit_demo.py` for a demonstration of the behavior with different matrix shapes.
+'''
+
+
+# %%
+from copterr import PermuteWeights, PermuteWeightsGrouped, alphas_to_deltas, quantize_alphas
+import numpy as np
+import torch
+import os
+from vm_tools.utils import avg_wts_torch
+from tqdm import tqdm
+import vm_tools as vmt
+import warnings
+warnings.filterwarnings("ignore", category=UserWarning)
+from tqdm import tqdm
+import re
+
+# %%
+# tall fake data with features: X1 be 8000x1000 (sample x feature1), X2 be 8000x500 (sample x feature2) Y be 8000x2000 (sample x voxel), alpha be 2x2000 (n_features x voxel)
+# currently the large dimension is only to demonstrate the speed difference between full_matrices=True and full_matrices=False, for initial testing, we should be fine with much smaller dimensions
+n_samples = 8000
+feature_numbers = 2
+n_features1 = 1000
+n_features2 = 500
+n_voxels = 2000
+trn_fs1 = torch.randn(n_samples, n_features1)
+trn_fs2 = torch.randn(n_samples, n_features2)
+trn_fs = [trn_fs1, trn_fs2]
+Y = torch.randn(n_samples, n_voxels)
+# this is consistent with the alpha
+alpha = torch.from_numpy(np.random.choice([1.e+02, 1.e+04, 1.e+06, 1.e+08, 1.e+10, 1.e+12, 1.e+14, 1.e+16, 1.e+18, 1.e+20, 1.e+22, 1.e+24, np.inf], size=(feature_numbers, n_voxels))).float()
+
+DEVICE = 'cuda:0'
+DTYPE = torch.float32
+
+# %%
+# took 32 seconds with full_matrices=True
+permuter = PermuteWeightsGrouped(trn_fs, Y, deltas=alphas_to_deltas(alpha), device=DEVICE, dtype=DTYPE)
+permuter.prepare()
+
+# %%
+# previously on main branch would yield error:
+# ---------------------------------------------------------------------------
+# ValueError                                Traceback (most recent call last)
+# ~/remote_mounts/pomcloud0/projects_shared/VMBA/notebooks/NSD_joseph_ipynbs/3_variance_partition/3.5_copterr_comit_demo.py in <module>
+#       1 # %%
+#       2 permuter = PermuteWeightsGrouped(trn_fs, Y, deltas=alphas_to_deltas(alpha), device=DEVICE, dtype=DTYPE, full_matrices=True)
+# ----> 3 permuter.prepare()
+
+# ~/anaconda3/envs/pomlab/lib/python3.7/site-packages/copterr/copterr.py in prepare(self, verbose)
+#      73             U, s, Vt = scipy.linalg.svd(self.X/scaling, full_matrices=self.full_matrices)
+#      74             d = s/(s**2 + 1)
+# ---> 75             VDUt = ((1/scaling * Vt).T * d) @ U.T
+#      76             # VDUt = ((1/scaling * Vt).T[:,:len(d)] * d) @ U.T
+#      77             # if full_matrices is True, then we should use this line
+
+# ValueError: matmul: Input operand 1 has a mismatch in its core dimension 0, with gufunc signature (n?,k),(k,m?)->(n?,m?) (size 80 is different from 15)
+# %%
+# took 9 seconds with full_matrices=False
+permuter = PermuteWeightsGrouped(trn_fs, Y, alphas=alpha, device=DEVICE, dtype=DTYPE, full_matrices=False)
+permuter.prepare()


### PR DESCRIPTION
Summary
Fix SVD dimension mismatch and optimize matrix computations. Added detailed documentation and backward compatibility for redundant delta_to_alpha conversion.

Main Changes:
1. Added dimension-aware matrix handling for SVD operations:
   - For wide matrices (samples < features): slice Vt.T
   - For tall matrices (samples > features): slice U.T
2. Maintained backward compatibility with full_matrices=True
3. Added optimized path using full_matrices=False that avoids computing unused matrix components
4. Added detailed documentation for copterr.py file.
5. Ensured backward compatibility for the `deltas` parameter.
6. Added explicit imports in the `__init__.py` file.

Technical Details:
- Previous code assumed wide matrices (common in fMRI).
- New code handles both wide and tall matrices correctly.
- Setting full_matrices=False is computationally optimal but optional.

Demonstration:
See `copterr/copterr_commit_demo.py` for a demonstration of the behavior with different matrix shapes.